### PR TITLE
chore: 드롭다운,select 기타 보완 (버블링, hover, 정렬, aria-attribute)

### DIFF
--- a/src/common/Dropdown/Dropdown.tsx
+++ b/src/common/Dropdown/Dropdown.tsx
@@ -85,7 +85,7 @@ const Dropdown = ({
             <li key={option.label}>
               <button
                 aria-label="드롭다운 메뉴"
-                className={cn("w-full px-3 py-2", `text-${textAlign}`)}
+                className={cn("w-full px-3 py-2 hover:bg-icon-inverse", `text-${textAlign}`)}
                 onClick={() => handleOptionClick(option)}
               >
                 <span className="text-md-regular text-text-primary">{option.label}</span>

--- a/src/common/Select/Select.tsx
+++ b/src/common/Select/Select.tsx
@@ -49,6 +49,7 @@ const Select = <T,>({ value, options, onChange, className, textAlign = "left" }:
   return (
     <div className="relative inline-block" ref={selectRef}>
       <button
+        aria-label="선택 버튼"
         className={cn(
           "flex justify-between items-center min-w-[110px] tablet:min-w-[120px] h-[44px] px-[10px] py-[14px] bg-background-primary border border-border-primary rounded-xl",
           className,
@@ -58,6 +59,7 @@ const Select = <T,>({ value, options, onChange, className, textAlign = "left" }:
         <span className="text-text-default text-md-medium">{selectedLabel}</span>
         <span>
           <Icon
+            aria-label="화살표"
             name="downArrow"
             className={cn("text-icon-primary transition-transform duration-300", isOpen && "rotate-180")}
           />
@@ -69,8 +71,9 @@ const Select = <T,>({ value, options, onChange, className, textAlign = "left" }:
           {options.map((option) => (
             <li key={option.label}>
               <button
+                aria-label="선택 메뉴"
                 className={cn(
-                  "w-full px-3 py-2",
+                  "w-full px-3 py-2 hover:bg-icon-inverse",
                   option.value === value && "bg-gray-100 font-semibold",
                   `text-${textAlign}`,
                 )}


### PR DESCRIPTION
# Pull Request

## 관련 이슈 <!-- 예시: close #123 / issue #123 -->
- 드롭다운 하위메뉴의 정렬타입 추가, 기본값은 bottom-left (주의할점 예시 - right: 오른쪽 끝을 기준으로 정렬)
- 드롭다운 이벤트 버블링 고려
- 드롭다운, select 모두 Hover 추가
- 드롭다운, select 모두 aria-attribute 추가

https://github.com/user-attachments/assets/000097c9-6d93-4ecf-b5ab-b14eb496b9ac



## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드 및 테스트 통과
- [ ] 불필요한 코드/주석 제거
- [ ] PR 제목과 라벨이 적절함
